### PR TITLE
Convert HTML to Markdown in place if code snippets are selected

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,14 @@
 `HTML to Markdown` extendsion convert HTML code snippet to markdown.
 
 ## Install
+
 Install `HTML to Markdown` from marketplace: [HTML to Markdown](https://marketplace.visualstudio.com/items?itemName=YangtangWu.html-to-markdown)
 
 ## Usage
+
 There is one available command:
-* `HTML to Markdown`: convert current opened editor HTML code snippet to Markdown and open a new tab.
+
+- `HTML to Markdown`: convert current opened editor HTML code snippet to Markdown and open a new tab. If HTML code snippets are selected in the current editor the HTML is converted to Markdown without opening a new tab.
 
 Press `F1` or `Ctrl + Shift + p` or `Cmd + Shift + p`(macOS) to open command palette, input `HTML to Markdonw`, then execute it.
 


### PR DESCRIPTION
If the HTML code is selected the conversion to Markdown is now performed in place, without opening a new tab.

Use case: adding (HTML) content to existing markdown documents.

The explicit type `Promise<void>` was causing the error `Illegal value for 'line'` documented [here](https://github.com/microsoft/vscode/issues/35393)